### PR TITLE
CorePack: add CorePackPreload

### DIFF
--- a/html/include/corepack_version.php
+++ b/html/include/corepack_version.php
@@ -1,0 +1,3 @@
+<?php
+// detaild_version for X-update
+define('_MI_LEGACY_DETAILED_VERSION', 'CorePack 20120804');

--- a/html/preload/CorePackPreload.class.php
+++ b/html/preload/CorePackPreload.class.php
@@ -1,0 +1,9 @@
+<?php
+
+// corepack version
+include_once(XOOPS_ROOT_PATH . '/include/corepack_version.php');
+
+class CorePackPreload extends XCube_ActionFilter
+{
+
+}


### PR DESCRIPTION
This time is define constat "_MI_LEGACY_DETAILED_VERSION" only.

X-update 用の detailed_version 対応として、定数 "_MI_LEGACY_DETAILED_VERSION" を定義しました。

今回 Preload を追加していますが、定数を定義しているだけです。 CorePack として他に Preload で処理したいことが出てきたときはこの CorePackPreload.class.php に追加していけばいいかなと思っています。
