### PR TITLE
legacy: admin theme onload func switch to onready

### DIFF
--- a/html/modules/legacy/admin/theme/admin_theme.html
+++ b/html/modules/legacy/admin/theme/admin_theme.html
@@ -143,8 +143,23 @@ function ccOpenCid()
 // ]]> -->
 </script>
 <{$xoops_module_header}>
+<script type="text/javascript">
+<!-- <![CDATA[
+if (typeof jQuery != 'undefined') {
+	jQuery(function($){
+		ccToggle(cid);
+		onloadEffect('leftcolumn', 'minimizelc', 'lcimage');
+	});
+} else {
+	document.body.onload = function(){
+		ccToggle(cid);
+		onloadEffect('leftcolumn', 'minimizelc', 'lcimage');
+	}
+}
+// ]]> -->
+</script>
 </head>
-<body onload="ccToggle(cid);onloadEffect('leftcolumn', 'minimizelc', 'lcimage');">
+<body>
 
 
 <div id="container">


### PR DESCRIPTION
X-update が preload で管理画面にデータ更新用 IMG タグを挿入している関係で、画面表示にもたつくことがあるのでその修正です。
body.onload の処理内容を dom.onready で行うようにしました。
