### PR TITLE
fix _cachedModule problem

### DIFF
--- a/html/kernel/module.php
+++ b/html/kernel/module.php
@@ -490,8 +490,8 @@ class XoopsModuleHandler extends XoopsObjectHandler
 			unset ($this->_cachedModule_mid[$mid]);
 		}
 		
-		$this->_cachedModule_dirname[$dirname] =& $module;
-		$this->_cachedModule_mid[$mid] =& $module;
+		$this->_cachedModule_dirname[$dirname] = $module;
+		$this->_cachedModule_mid[$mid] =& $this->_cachedModule_dirname[$dirname];
 
 		if (XC_CLASS_EXISTS('Legacy_AdminSideMenu')) {
 			Legacy_AdminSideMenu::clearCache();


### PR DESCRIPTION
[ja]
参照渡しで受け取ったオブジェクト($module)を参照渡しでキャッシュしているため
foreach 文の中からなど $module に違うオブジェクトを入れ替えて複数回 insert()
を呼び出している場合にキャッシュキーの中身が入れ替わってしまう。

他の解決策としては

プラン 1

kernel/module.php L.455

function insert(&$module)

を

function insert($module)

プラン 2

module/legacy/admin/actions/ModuleListAction.class.php L.106

追加

unset($module);

などが考えられます。
[/ja]
