### PR TITLE
Xoops dhtmltarea editor class

### DIFF
--- a/xoops_trust_path/libs/smarty/plugins/function.xoops_dhtmltarea.php
+++ b/xoops_trust_path/libs/smarty/plugins/function.xoops_dhtmltarea.php
@@ -62,7 +62,7 @@ function smarty_function_xoops_dhtmltarea($params, &$smarty)
 		$params['value'] = isset($params['value']) ? $textFilter->toEdit($params['value']) : null;
 		$params['id'] = isset($params['id']) ? trim($params['id']) : XOOPS_DHTMLTAREA_DEFID_PREFIX . $params['name'];
 	
-		if (!empty($params['editor'])) {
+		if (!empty($params['editor']) && $params['editor'] !== 'none') {
 			if (! $params['class']) {
 				$params['class'] = $params['editor'];
 			} else {
@@ -80,6 +80,7 @@ function smarty_function_xoops_dhtmltarea($params, &$smarty)
 			break;
 		
 		case 'none':
+		case 'plain':
 			XCube_DelegateUtils::call("Site.TextareaEditor.None.Show", new XCube_Ref($html), $params);
 			break;
 		case 'bbcode':

--- a/xoops_trust_path/libs/smarty/plugins/function.xoops_dhtmltarea.php
+++ b/xoops_trust_path/libs/smarty/plugins/function.xoops_dhtmltarea.php
@@ -62,6 +62,14 @@ function smarty_function_xoops_dhtmltarea($params, &$smarty)
 		$params['value'] = isset($params['value']) ? $textFilter->toEdit($params['value']) : null;
 		$params['id'] = isset($params['id']) ? trim($params['id']) : XOOPS_DHTMLTAREA_DEFID_PREFIX . $params['name'];
 	
+		if (!empty($params['editor'])) {
+			if (! $params['class']) {
+				$params['class'] = $params['editor'];
+			} else {
+				$params['class'] .= ' ' . $params['editor'];
+			}
+		}
+		
 		//
 		// Build the object for output.
 		//


### PR DESCRIPTION
Smarty プラグインの <xoops_dhtmltarea> で、 editor の値を class名 に含める試みです。

CSS class名 として none は、テーマによっては非表示になる場合があるので、none の場合は class
名を付加せず、 none と同等の plain を追加してあります。
