### PR TITLE
[user] fix csv data import function

### DIFF
--- a/html/modules/user/admin/actions/UserDataDownloadAction.class.php
+++ b/html/modules/user/admin/actions/UserDataDownloadAction.class.php
@@ -77,7 +77,10 @@ class User_UserDataDownloadAction extends User_Action
 		
 		/// japanese 
 		if (strncasecmp($GLOBALS['xoopsConfig']['language'], 'ja', 2)===0){
-			mb_convert_variables('SJIS', _CHARSET, $text);
+			if (_CHARSET !== 'UTF-8') {
+				mb_convert_variables('UTF-8', _CHARSET, $text);
+			}
+			$text = pack('C*',0xEF,0xBB,0xBF) . $text;
 		}
 		
 		if( preg_match('/firefox/i' , xoops_getenv('HTTP_USER_AGENT')) ){


### PR DESCRIPTION
user モジュールの一括登録のバグ修正
- UTF-8 日本語環境で Shift-JIS に存在しない文字が処理できない問題の修正
- ユーザーデータに改行が含まれる場合に正常にインポートできない問題を修正

日本語環境下では、UTF-8(BOM付)にて CSV ファイルを出力するようにした。
改行問題は、 fgetcsv() を使い処理を行うようにした。
