### PR TITLE
correction of error_reporting for PHP >= 5.4

### DIFF
--- a/html/install/index.php
+++ b/html/install/index.php
@@ -12,8 +12,7 @@
  |   keeping compatibility with XOOPS 2.0.x <http://www.xoops.org>        |
  *------------------------------------------------------------------------*/
 
-if (E_ALL > 30719) {
-	// PHP >= 5.4
+if (version_compare(PHP_VERSION, '5.4.0', '>=') && error_reporting() === E_ALL) {
 	error_reporting(E_ALL ^ E_STRICT);
 }
 

--- a/html/install/index.php
+++ b/html/install/index.php
@@ -12,6 +12,11 @@
  |   keeping compatibility with XOOPS 2.0.x <http://www.xoops.org>        |
  *------------------------------------------------------------------------*/
 
+if (E_ALL > 30719) {
+	// PHP >= 5.4
+	error_reporting(E_ALL ^ E_STRICT);
+}
+
 include_once './passwd.php';
 if(INSTALL_USER != '' || INSTALL_PASSWD != ''){
     if (!isset($_SERVER['PHP_AUTH_USER'])) {

--- a/html/modules/legacy/class/Legacy_Debugger.class.php
+++ b/html/modules/legacy/class/Legacy_Debugger.class.php
@@ -89,8 +89,7 @@ class Legacy_PHPDebugger extends Legacy_AbstractDebugger
 {
 	function prepare()
 	{
-		if (E_ALL > 30719) {
-			// PHP >= 5.4
+		if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
 			error_reporting(E_ALL ^ E_STRICT);
 		} else {
 			error_reporting(E_ALL);

--- a/html/modules/legacy/class/Legacy_Debugger.class.php
+++ b/html/modules/legacy/class/Legacy_Debugger.class.php
@@ -89,7 +89,12 @@ class Legacy_PHPDebugger extends Legacy_AbstractDebugger
 {
 	function prepare()
 	{
-		error_reporting(E_ALL);
+		if (E_ALL > 30719) {
+			// PHP >= 5.4
+			error_reporting(E_ALL ^ E_STRICT);
+		} else {
+			error_reporting(E_ALL);
+		}
 		$GLOBALS['xoopsErrorHandler'] =& XoopsErrorHandler::getInstance();
 		$GLOBALS['xoopsErrorHandler']->activate(true);
 	}


### PR DESCRIPTION
PHP 5.4 から E_ALL に E_STRICT が含まれるようになったことで、strict error が鬼のようにでてしまうので、とりあえず strict error を表示しないようにしてみました。

もちろん、 根本的には E_ALL でエラー表示がされない改修をすべきとは思いますが、そろそろ PHP 5.4 で動作させる人も増えてくると思いますので、「取り急ぎ」の対策でもしたほうがよいと思います。
