### PR TITLE
support editor delegate with xoopsform dhtmltarea

### DIFF
--- a/html/class/xoopsform/formdhtmltextarea.php
+++ b/html/class/xoopsform/formdhtmltextarea.php
@@ -97,14 +97,15 @@ class XoopsFormDhtmlTextArea extends XoopsFormTextArea
     {
 		$root =& XCube_Root::getSingleton();
 
-		if ($this->_editor) {
+		$editor = $this->getEditor();
+		if ($editor) {
 			$params['name'] = trim($this->getName(false));
 			$params['class'] = trim($this->getClass());
 			$params['cols'] = $this->getCols();
 			$params['rows'] = $this->getRows();
 			$params['value'] = $this->getValue();
 			$params['id'] = $this->getId();
-			$params['editor'] = $this->getEditor();
+			$params['editor'] = $editor;
 
 			$html = '';
 			switch ($params['editor']) {

--- a/html/class/xoopsform/formdhtmltextarea.php
+++ b/html/class/xoopsform/formdhtmltextarea.php
@@ -71,7 +71,15 @@ class XoopsFormDhtmlTextArea extends XoopsFormTextArea
      * @access  private
      */
     private $_editor;
-
+    
+    /**
+     * Editor check for recursive prevention
+     * @static
+     * @var array
+     * @access  private
+     */
+    private static $_editorCheck = array();
+    
     /**
      * Constructor
      *
@@ -98,7 +106,8 @@ class XoopsFormDhtmlTextArea extends XoopsFormTextArea
 		$root =& XCube_Root::getSingleton();
 
 		$editor = $this->getEditor();
-		if ($editor) {
+		if ($editor && !isset(self::$_editorCheck[$id])) {
+			self::$_editorCheck[$id] = true;
 			$params['name'] = trim($this->getName(false));
 			$params['class'] = trim($this->getClass());
 			$params['cols'] = $this->getCols();

--- a/html/class/xoopsform/formdhtmltextarea.php
+++ b/html/class/xoopsform/formdhtmltextarea.php
@@ -64,6 +64,13 @@ class XoopsFormDhtmlTextArea extends XoopsFormTextArea
      * @access  private
      */
     var $_hiddenText;
+    
+    /**
+     * Editor type
+     * @var string
+     * @access  private
+     */
+    private $_editor;
 
     /**
      * Constructor
@@ -89,6 +96,33 @@ class XoopsFormDhtmlTextArea extends XoopsFormTextArea
     function render()
     {
 		$root =& XCube_Root::getSingleton();
+
+		if ($this->_editor) {
+			$params['name'] = trim($this->getName(false));
+			$params['class'] = trim($this->getClass());
+			$params['cols'] = $this->getCols();
+			$params['rows'] = $this->getRows();
+			$params['value'] = $this->getValue();
+			$params['id'] = $this->getId();
+			$params['editor'] = $this->getEditor();
+
+			$html = '';
+			switch ($params['editor']) {
+				case 'html':
+					XCube_DelegateUtils::call('Site.TextareaEditor.HTML.Show', new XCube_Ref($html), $params);
+					break;
+				case 'none':
+					XCube_DelegateUtils::call('Site.TextareaEditor.None.Show', new XCube_Ref($html), $params);
+					break;
+				case 'bbcode':
+				default:
+					XCube_DelegateUtils::call('Site.TextareaEditor.BBCode.Show', new XCube_Ref($html), $params);
+					break;
+			}
+
+			return $html;
+		}
+
 		$renderSystem =& $root->getRenderSystem(XOOPSFORM_DEPENDENCE_RENDER_SYSTEM);
 		
 		$renderTarget =& $renderSystem->createRenderTarget('main');
@@ -129,5 +163,24 @@ class XoopsFormDhtmlTextArea extends XoopsFormTextArea
 		
 		return $renderTarget->getResult();
     }
+
+	/**
+	 * set editor mode for XCL 2.2
+	 *
+	 * @param  string  editor type
+	 */
+	function setEditor($editor) {
+		$this->_editor = strtolower($editor);
+	}
+
+	/**
+	 * get the "editor" value
+	 *
+	 * @return 	string  editor type
+	 */
+	function getEditor() {
+		return $this->_editor;
+	}
+
 }
 ?>


### PR DESCRIPTION
ex.

``` php
$tarea = new XoopsFormDhtmlTextArea('', 'body' , '') ;
if (method_exists($tarea, 'setEditor')) {
    $tarea->setEditor($allow_html? 'html' : 'bbcode');
}
```

[ja]
XCL 2.2 から採用された HTML エディタ仕様に対応した XoopsFormDhtmlTextArea です。
Smarty テンプレートを利用せず、XoopsForm オブジェクトを利用してレンダリングするフォームでも
HTML エディタの切り替えが可能になります。
[/ja]
