### PR TITLE
[installer] lang select only utf8 & en on PHP>=5.4

### DIFF
--- a/html/install/wizards/install_langselect.inc.php
+++ b/html/install/wizards/install_langselect.inc.php
@@ -11,7 +11,9 @@
         define('_INSTALL_L128', 'Choose language to be used for the installation process');
     }
     $langarr = getDirList('./language/');
+    $php54 = (version_compare(PHP_VERSION, '5.4.0') >= 0);
     foreach ($langarr as $lang) {
+        if ($php54 && $lang !== 'english' && substr($lang, -5) !== '_utf8') continue;
         $wizard->addArray('languages', $lang);
         if (strtolower($lang) == $language) {
             $wizard->addArray('selected','selected="selected"');


### PR DESCRIPTION
PHP 5.4 以降では htmlspecialchars() の仕様変更により、UTF-8 環境以外では XOOPS がまともに動かなくなっていることから、PHP 5.4 以降の環境では、インストーラーで表示される言語を english と *_utf8 のみにしました。
