### PR TITLE
[legacy:TextFilter] support HTMLPurifier >= 4.4.0

### DIFF
--- a/html/modules/legacy/kernel/Legacy_TextFilter.class.php
+++ b/html/modules/legacy/kernel/Legacy_TextFilter.class.php
@@ -191,23 +191,41 @@ class Legacy_TextFilter extends XCube_TextFilter
 	 * @param	string	$html
 	 * @param	string	$encoding
 	 * @param	string	$doctype
+	 * @param	object	$config
 	 * 
 	 * @return	string
 	 **/
-	public function purifyHtml(/*** string ***/ $html, /*** string ***/ $encoding=null, /*** string ***/ $doctype=null)
+	public function purifyHtml(/*** string ***/ $html, /*** string ***/ $encoding=null, /*** string ***/ $doctype=null, /*** object ***/ $config=null)
 	{
 		require_once XOOPS_LIBRARY_PATH.'/htmlpurifier/library/HTMLPurifier.auto.php';
 		$encoding = $encoding ? $encoding : _CHARSET; 
 		$doctypeArr = array("HTML 4.01 Strict","HTML 4.01 Transitional","XHTML 1.0 Strict","XHTML 1.0 Transitional","XHTML 1.1");
 	
-		$config = HTMLPurifier_Config::createDefault();
-		$config->set('Core.Encoding', $encoding);
-		if(in_array($doctype, $doctypeArr)){
-			$config->set('HTML.Doctype', $doctype);
+		if (is_null($config) || !is_object($config) || !($config instanceof HTMLPurifier_Config)) {
+			$config = HTMLPurifier_Config::createDefault();
+			if(in_array($doctype, $doctypeArr)){
+				$config->set('HTML.Doctype', $doctype);
+			}
+		}
+	
+		if ($_conv = ($encoding !== 'UTF-8' && function_exists('mb_convert_encoding'))) {
+			$_substitute = mb_substitute_character();
+			mb_substitute_character('none');
+			$html = mb_convert_encoding($html, 'UTF-8', $encoding);
+			$config->set('Core.Encoding', 'UTF-8');
+		} else {
+			$config->set('Core.Encoding', $encoding);
 		}
 	
 		$purifier = new HTMLPurifier($config);
-		return $purifier->purify($html);
+		$html = $purifier->purify($html);
+	
+		if ($_conv) {
+			$html = mb_convert_encoding($html, $encoding, 'UTF-8');
+			mb_substitute_character($_substitute);
+		}
+	
+		return $html;
 	}
 
 

--- a/xoops_trust_path/libs/smarty/plugins/modifier.xoops_html_purifier.php
+++ b/xoops_trust_path/libs/smarty/plugins/modifier.xoops_html_purifier.php
@@ -30,13 +30,28 @@ function smarty_modifier_xoops_html_purifier($html, $ecoding=null, $doctype=null
 	$doctypeArr = array("HTML 4.01 Strict","HTML 4.01 Transitional","XHTML 1.0 Strict","XHTML 1.0 Transitional","XHTML 1.1");
 
 	$config = HTMLPurifier_Config::createDefault();
-	$config->set('Core.Encoding', $encoding);
 	if(in_array($doctype, $doctypeArr)){
 		$config->set('HTML.Doctype', $doctype);
 	}
 
+	if ($_conv = ($encoding !== 'UTF-8' && function_exists('mb_convert_encoding'))) {
+		$_substitute = mb_substitute_character();
+		mb_substitute_character('none');
+		$html = mb_convert_encoding($html, 'UTF-8', $encoding);
+		$config->set('Core.Encoding', 'UTF-8');
+	} else {
+		$config->set('Core.Encoding', $encoding);
+	}
+
 	$purifier = new HTMLPurifier($config);
-	return $purifier->purify($html);
+	$html = $purifier->purify($html);
+
+	if ($_conv) {
+		$html = mb_convert_encoding($html, $encoding, 'UTF-8');
+		mb_substitute_character($_substitute);
+	}
+
+	return $html;
 }
 
 ?>


### PR DESCRIPTION
[ja]HTMLPurifier 4.4.0 以上に対応するための修正です。 HTMLPurifier 4.4.0 以上では、iconv のバグが修正されるまで、UTF-8 以外の入力は受け付けないので、そのための修正です。

また、 Legacy_TextFilter::purifyHtml() の第4引数に HTMLPurifier_Config オブジェクトを渡せるようにしてみました。[/ja]

ref. http://repo.or.cz/w/htmlpurifier.git/blobdiff/ce68cfe48477e1e76b3090bbae698ac70a333a4b..94c15d1f5629e93e94724168e82a0727f52abadb:/library/HTMLPurifier/Encoder.php
