### PR TITLE
[user] add delegate points before xoopsmailer->send() with `xoopsmailer`

### DIFF
--- a/html/class/xoopsmailer.php
+++ b/html/class/xoopsmailer.php
@@ -130,6 +130,27 @@ class XoopsMailer
 	// protected
 	var $encoding = '8bit';
 
+	private $properties = array(
+		'fromEmail'    => "",
+		'fromName'     => "",
+		'fromUser'     => null, // RMV-NOTIFY
+		'priority'     => '',
+		'toUsers'      => array(),
+		'toEmails'     => array(),
+		'headers'      => array(),
+		'subject'      => "",
+		'body'         => "",
+		'errors'       => array(),
+		'success'      => array(),
+		'isMail'       => false,
+		'isPM'         => false,
+		'assignedTags' => array(),
+		'template'     => "",
+		'templatedir'  => "",
+		// Change below to \r\n if you have problem sending mail
+		'LE'           => "\n"
+	);
+
 	function XoopsMailer()
 	{
 
@@ -141,24 +162,9 @@ class XoopsMailer
 	// reset all properties to default
 	function reset()
 	{
-		$this->fromEmail = "";
-		$this->fromName = "";
-		$this->fromUser = null; // RMV-NOTIFY
-		$this->priority = '';
-		$this->toUsers = array();
-		$this->toEmails = array();
-		$this->headers = array();
-		$this->subject = "";
-		$this->body = "";
-		$this->errors = array();
-		$this->success = array();
-		$this->isMail = false;
-		$this->isPM = false;
-		$this->assignedTags = array();
-		$this->template = "";
-		$this->templatedir = "";
-		// Change below to \r\n if you have problem sending mail
-		$this->LE ="\n";
+		foreach($this->properties as $key => $val) {
+			$this->$key = $val;
+		}
 	}
 
 	// public
@@ -226,6 +232,14 @@ class XoopsMailer
 	function usePM()
 	{
 		$this->isPM = true;
+	}
+
+	public function getVar($key) {
+		if (isset($this->properties[$key])) {
+			return $this->$key;
+		} else {
+			return null;
+		}
 	}
 
 	// public

--- a/html/modules/user/actions/LostPassAction.class.php
+++ b/html/modules/user/actions/LostPassAction.class.php
@@ -74,6 +74,7 @@ class User_LostPassAction extends User_Action
 		$director =new User_LostPassMailDirector($builder, $lostUser, $controller->mRoot->mContext->getXoopsConfig(), $extraVars);
 		$director->contruct();
 		$xoopsMailer =& $builder->getResult();
+		XCube_DelegateUtils::call('Legacy.Event.RegistUser.SendMail', new XCube_Ref($xoopsMailer), 'LostPass2');
 		if (!$xoopsMailer->send()) {
 			// $xoopsMailer->getErrors();
 			return USER_FRAME_VIEW_ERROR;
@@ -107,6 +108,7 @@ class User_LostPassAction extends User_Action
 		$director =new User_LostPassMailDirector($builder, $lostUser, $controller->mRoot->mContext->getXoopsConfig());
 		$director->contruct();
 		$xoopsMailer =& $builder->getResult();
+		XCube_DelegateUtils::call('Legacy.Event.RegistUser.SendMail', new XCube_Ref($xoopsMailer), 'LostPass1');
 
 		if (!$xoopsMailer->send()) {
 			// $xoopsMailer->getErrors();

--- a/html/modules/user/actions/UserActivateAction.class.php
+++ b/html/modules/user/actions/UserActivateAction.class.php
@@ -66,6 +66,7 @@ class User_UserActivateAction extends User_AbstractEditAction
 			$director =new User_UserRegistMailDirector($builder, $this->mObject, $controller->mRoot->mContext->getXoopsConfig(), $this->mConfig);
 			$director->contruct();
 			$mailer=&$builder->getResult();
+			XCube_DelegateUtils::call('Legacy.Event.RegistUser.SendMail', new XCube_Ref($mailer), 'Activated');
 			if ($mailer->send()) {
 				$controller->executeRedirect(XOOPS_URL . '/', 5, sprintf(_MD_USER_MESSAGE_ACTVMAILOK, $this->mObject->get('uname')));
 			} else {

--- a/html/modules/user/actions/UserRegister_confirmAction.class.php
+++ b/html/modules/user/actions/UserRegister_confirmAction.class.php
@@ -114,6 +114,7 @@ class User_UserRegister_confirmAction extends User_Action
 		$director =new User_UserRegistMailDirector($builder, $this->mNewUser, $controller->mRoot->mContext->getXoopsConfig(), $this->mConfig);
 		$director->contruct();
 		$mailer =& $builder->getResult();
+		XCube_DelegateUtils::call('Legacy.Event.RegistUser.SendMail', new XCube_Ref($mailer), ($activationType == 0)? 'Register' : 'AdminActivate');
 		
 		if (!$mailer->send()) {
 		}	// TODO CHECKS and use '_MD_USER_ERROR_YOURREGMAILNG'
@@ -126,6 +127,7 @@ class User_UserRegister_confirmAction extends User_Action
 			$director =new User_UserRegistMailDirector($builder, $this->mNewUser, $controller->mRoot->mContext->getXoopsConfig(), $this->mConfig);
 			$director->contruct();
 			$mailer =& $builder->getResult();
+			XCube_DelegateUtils::call('Legacy.Event.RegistUser.SendMail', new XCube_Ref($mailer), 'Notify');
 			$mailer->send();
 		}
 	}


### PR DESCRIPTION
[user] add delegate points before xoopsmailer->send() with `xoopsmailer`
- sample preload (html/preload/UserPreSendMail.class.php)

``` php
<?php

class UserPreSendMail extends XCube_ActionFilter
{
    function postFilter() {
        $this->mRoot->mDelegateManager->add('Legacy.Event.RegistUser.SendMail'
, array($this ,'preSendMail'));
    }

    function preSendMail(&$mailer, $action) {

        /* COMMON PROCESS */

        /* EDIT SUBJECT */
        //$subject = $mailer->getVar('subject');
        //$mailer->setSubject('['.$action.'] ' . $subject);

        /* CHANGE MAIL FROM */
        //$mailer->setFromEmail('example@example.com');
        //$mailer->setFromName('XOOPS Cube Legacy Site');


        /* PROCESS OF EACH ACTION */

        switch($action) {
            case 'LostPass1' :
                break;
            case 'LostPass2' :
                break;
            case 'Activated' :
                break;
            case 'Register' :
                /* CHANGE TEMPLATE */
                //$mailer->setTemplate('register_custom.tpl');
                break;
            case 'AdminActivate' :
                break;
            case 'Notify' :
                break;
        }
    }
}
```
