### PR TITLE
[pilot] Added the switch "XOOPS_LOGGER_ADDQUERY_DISABLED" to reduce m…

### DIFF
--- a/html/class/logger.php
+++ b/html/class/logger.php
@@ -108,6 +108,9 @@ class XoopsLogger
      */
     public function addQuery($sql, $error=null, $errno=null)
     {
+        if (defined('XOOPS_LOGGER_ADDQUERY_DISABLED') && XOOPS_LOGGER_ADDQUERY_DISABLED) {
+            return;
+        }
         $this->queries[] = array('sql' => $sql, 'error' => $error, 'errno' => $errno);
     }
 


### PR DESCRIPTION
…emory consumption.

Sending PR again.

I was annoying at XoopsLogger used too much memory when I ran a huge batch.

You can stop logging too many sql queries when set XOOPS_LOGGER_ADDQUERY_DISABLED=true.

Referred to http://qiita.com/RyujiAMANO/items/e529b955eeac99796023

Thank you.
