### PR TITLE
Exporting mysql errors to httpd error log file

### DIFF
--- a/html/class/logger.php
+++ b/html/class/logger.php
@@ -112,6 +112,9 @@ class XoopsLogger
             return;
         }
         $this->queries[] = array('sql' => $sql, 'error' => $error, 'errno' => $errno);
+        if ($error && defined('XOOPS_MYSQL_ERROR_LOG') && XOOPS_MYSQL_ERROR_LOG) {
+            error_log("XOOPS_MYSQL_ERROR_LOG: " . print_r(end($this->queries), true));
+        }
     }
 
     /**


### PR DESCRIPTION
I was annoyed that xoops showed me the mysql query errors only on browsers when the debug mode was on. But we need to know the error without showing customers.

You can output your mysql errors into your httpd error log when you insert this line below into your config.php.

```
define("XOOPS_MYSQL_ERROR_LOG", 1); // Export mysql query errors into your httpd error log
```

I'd appreciate it if you could accept this PR.

Thank you,
