### PR TITLE
Suppress constructer warnings for php 7.x

### DIFF
--- a/html/kernel/configcategory.php
+++ b/html/kernel/configcategory.php
@@ -59,6 +59,10 @@ class XoopsConfigCategory extends XoopsObject
      */
     public function XoopsConfigCategory()
     {
+        return self::__construct();
+    }
+    public function __construct()
+    {
         $this->XoopsObject();
         $this->initVar('confcat_id', XOBJ_DTYPE_INT, null);
         $this->initVar('confcat_name', XOBJ_DTYPE_OTHER, null);

--- a/html/kernel/tplset.php
+++ b/html/kernel/tplset.php
@@ -36,6 +36,10 @@ class XoopsTplset extends XoopsObject
 
     public function XoopsTplset()
     {
+        return self::__construct();
+    }
+    public function __construct()
+    {
         static $initVars;
         if (isset($initVars)) {
             $this->vars = $initVars;

--- a/html/modules/legacy/admin/actions/ModuleInstallAction.class.php
+++ b/html/modules/legacy/admin/actions/ModuleInstallAction.class.php
@@ -88,9 +88,9 @@ class Legacy_ModuleInstallAction extends Legacy_Action
      */
     public $mInstaller = null;
     
-    public function Legacy_ModuleInstallAction($flag)
+    public function __construct($flag)
     {
-        parent::Legacy_Action($flag);
+        parent::__construct($flag);
         
         $this->mInstallSuccess =new XCube_Delegate();
         $this->mInstallSuccess->register('Legacy_ModuleInstallAction.InstallSuccess');

--- a/html/modules/legacy/admin/actions/ModuleUninstallAction.class.php
+++ b/html/modules/legacy/admin/actions/ModuleUninstallAction.class.php
@@ -92,7 +92,7 @@ class Legacy_ModuleUninstallAction extends Legacy_Action
     
     public function Legacy_ModuleUninstallAction($flag)
     {
-        parent::Legacy_Action($flag);
+        parent::__construct($flag);
         
         $this->mUninstallSuccess =new XCube_Delegate();
         $this->mUninstallSuccess->register('Legacy_ModuleUninstallAction.UninstallSuccess');


### PR DESCRIPTION
Thanks for merging previous patch.
I noticed other fixes.

Constructer fixes for kernel and module legacy.