### PR TITLE
インストールできない不具合修正

### DIFF
--- a/html/modules/message/admin/class/myInstaller.class.php
+++ b/html/modules/message/admin/class/myInstaller.class.php
@@ -11,10 +11,18 @@ require_once XOOPS_ROOT_PATH.'/modules/legacy/admin/class/ModuleInstaller.class.
 
 class Message_myInstaller extends Legacy_ModuleInstaller
 {
-	public function __construct() 
+    /**
+     * For backward compatibility
+     */
+    public function Message_myInstaller()
     {
-		parent::__construct();
-	}
+        self::__construct();
+    }
+
+    public function __construct() 
+    {
+        parent::__construct();
+    }
 
     public function executeInstall()
     {

--- a/html/modules/message/admin/class/myInstaller.class.php
+++ b/html/modules/message/admin/class/myInstaller.class.php
@@ -11,11 +11,11 @@ require_once XOOPS_ROOT_PATH.'/modules/legacy/admin/class/ModuleInstaller.class.
 
 class Message_myInstaller extends Legacy_ModuleInstaller
 {
-    public function Message_myInstaller()
+	public function __construct() 
     {
-        parent::Legacy_ModuleInstaller();
-    }
-  
+		parent::__construct();
+	}
+
     public function executeInstall()
     {
         if (version_compare(PHP_VERSION, '5.0.0', '>')) {


### PR DESCRIPTION
親クラスのLegacy_ModuleInstallerのコンストラクタがクラス同名メソッドから__construct()に変更になってたので。